### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.0.1",
   "name": "feugene/laravel-files",
   "description": "Laravel files model",
   "keywords": [
@@ -13,20 +12,20 @@
     }
   ],
   "require": {
-    "php": ">7.1 <=7.3",
-    "illuminate/database": "~5.6",
+    "php": ">7.1.3",
+    "illuminate/database": ">=5.6.0 <5.8.0",
     "ramsey/uuid": "^3.8",
     "symfony/http-foundation": "~4",
-    "efureev/support": "*"
+    "efureev/support": "^1.2"
   },
   "require-dev": {
     "mockery/mockery": "^1.2",
     "avto-dev/dev-tools": "^1.7",
     "fzaninotto/faker": "^1.8",
-    "phpstan/phpstan": "*",
+    "phpstan/phpstan": "^0.10.2",
     "phpunit/phpunit": "^7.0",
-    "efureev/php-cs-fixer": "*",
-    "laravel/laravel": "*"
+    "efureev/php-cs-fixer": "^1.0",
+    "laravel/laravel": ">=5.6.0 <5.8.0"
   },
   "extra": {
     "laravel": {


### PR DESCRIPTION
Итак, по порядку:

- `version` не надо указывать, так как значение версии берётся из тегов (релизов)
- `php` минимальной лучше не `7.1`, а `7.1.3`. т.к. в `*.3` поправили много разных штук (в том чиста связанные с DateTime, на сколько помню). Максимальную версию приколачивать смысла не вижу, так как тестировать хочется включая ночные сборки php ([пример конфига travis](https://github.com/avto-dev/events-log-laravel/blob/816c6c7f0d87cd4a008cb051d28cf560ebb4be8d/.travis.yml#L54))
- `illuminate/database` как и `laravel/laravel` лучше указывать с минимальной по максимальную, явно. Если с минимальной всё понятно, то с максимальной - ты же не можешь гарантировать что всё будет работать как необходимо после мажорного обновления зависимого пакета
- `phpstan/phpstan` - у него сильные изменения, связанные как с мажором, так и минором. Лучше тоже "приколачивать" версию (тем более что `dev`-зависимость)
- `efureev/support` и `efureev/php-cs-fixer` - всегда указывай, как минимум нажорную версию. Просто `*` - зло злючее

И поставь уже для шторма https://github.com/kalessil/phpinspectionsea - он бы тебе всё выше описанное сам подсказал :)